### PR TITLE
Remove pandas dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,8 +5,6 @@ name = "pypi"
 
 [packages]
 requests = "*"
-pandas = "*"
-xlrd = "*"
 
 [dev-packages]
 pre-commit = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "74ce60b1993a551caa3d6b8ca6a607be9b86752f39618cd3b1990b9165fe870e"
+            "sha256": "43da11c92f005406262af03b39d1a5b14ddbdb3e7fa42b2da92ddc0f866d3825"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -39,76 +39,6 @@
             "markers": "python_version >= '3'",
             "version": "==3.3"
         },
-        "numpy": {
-            "hashes": [
-                "sha256:0d245a2bf79188d3f361137608c3cd12ed79076badd743dc660750a9f3074f7c",
-                "sha256:26b4018a19d2ad9606ce9089f3d52206a41b23de5dfe8dc947d2ec49ce45d015",
-                "sha256:2db01d9838a497ba2aa9a87515aeaf458f42351d72d4e7f3b8ddbd1eba9479f2",
-                "sha256:3d62d6b0870b53799204515145935608cdeb4cebb95a26800b6750e48884cc5b",
-                "sha256:45a7dfbf9ed8d68fd39763940591db7637cf8817c5bce1a44f7b56c97cbe211e",
-                "sha256:4ac4d7c9f8ea2a79d721ebfcce81705fc3cd61a10b731354f1049eb8c99521e8",
-                "sha256:60f19c61b589d44fbbab8ff126640ae712e163299c2dd422bfe4edc7ec51aa9b",
-                "sha256:632e062569b0fe05654b15ef0e91a53c0a95d08ffe698b66f6ba0f927ad267c2",
-                "sha256:65f5e257987601fdfc63f1d02fca4d1c44a2b85b802f03bd6abc2b0b14648dd2",
-                "sha256:69958735d5e01f7b38226a6c6e7187d72b7e4d42b6b496aca5860b611ca0c193",
-                "sha256:78bfbdf809fc236490e7e65715bbd98377b122f329457fffde206299e163e7f3",
-                "sha256:7e957ca8112c689b728037cea9c9567c27cf912741fabda9efc2c7d33d29dfa1",
-                "sha256:800dfeaffb2219d49377da1371d710d7952c9533b57f3d51b15e61c4269a1b5b",
-                "sha256:831f2df87bd3afdfc77829bc94bd997a7c212663889d56518359c827d7113b1f",
-                "sha256:88d54b7b516f0ca38a69590557814de2dd638d7d4ed04864826acaac5ebb8f01",
-                "sha256:8d1563060e77096367952fb44fca595f2b2f477156de389ce7c0ade3aef29e21",
-                "sha256:b5ec9a5eaf391761c61fd873363ef3560a3614e9b4ead17347e4deda4358bca4",
-                "sha256:bcd19dab43b852b03868796f533b5f5561e6c0e3048415e675bec8d2e9d286c1",
-                "sha256:c51124df17f012c3b757380782ae46eee85213a3215e51477e559739f57d9bf6",
-                "sha256:e348ccf5bc5235fc405ab19d53bec215bb373300e5523c7b476cc0da8a5e9973",
-                "sha256:e60ef82c358ded965fdd3132b5738eade055f48067ac8a5a8ac75acc00cad31f",
-                "sha256:f8ad59e6e341f38266f1549c7c2ec70ea0e3d1effb62a44e5c3dba41c55f0187"
-            ],
-            "markers": "python_version < '3.10' and platform_machine != 'aarch64' and platform_machine != 'arm64'",
-            "version": "==1.22.1"
-        },
-        "pandas": {
-            "hashes": [
-                "sha256:0f19504f2783526fb5b4de675ea69d68974e21c1624f4b92295d057a31d5ec5f",
-                "sha256:156aac90dd7b303bf0b91bae96c0503212777f86c731e41929c571125d26c8e9",
-                "sha256:1d59c958d6b8f96fdf850c7821571782168d5acfe75ccf78cd8d1ac15fb921df",
-                "sha256:1f3b74335390dda49f5d5089fab71958812bf56f42aa27663ee4c16d19f4f1c5",
-                "sha256:23c04dab11f3c6359cfa7afa83d3d054a8f8c283d773451184d98119ef54da97",
-                "sha256:2dad075089e17a72391de33021ad93720aff258c3c4b68c78e1cafce7e447045",
-                "sha256:46a18572f3e1cb75db59d9461940e9ba7ee38967fa48dd58f4139197f6e32280",
-                "sha256:4a8d5a200f8685e7ea562b2f022c77ab7cb82c1ca5b240e6965faa6f84e5c1e9",
-                "sha256:51e5da3802aaee1aa4254108ffaf1129a15fb3810b7ce8da1ec217c655b418f5",
-                "sha256:5229c95db3a907451dacebc551492db6f7d01743e49bbc862f4a6010c227d187",
-                "sha256:5280d057ddae06fe4a3cd6aa79040b8c205cd6dd21743004cf8635f39ed01712",
-                "sha256:55ec0e192eefa26d823fc25a1f213d6c304a3592915f368e360652994cdb8d9a",
-                "sha256:73f7da2ccc38cc988b74e5400b430b7905db5f2c413ff215506bea034eaf832d",
-                "sha256:784cca3f69cfd7f6bd7c7fdb44f2bbab17e6de55725e9ff36d6f382510dfefb5",
-                "sha256:b5af258c7b090cca7b742cf2bd67ad1919aa9e4e681007366c9edad2d6a3d42b",
-                "sha256:cdd76254c7f0a1583bd4e4781fb450d0ebf392e10d3f12e92c95575942e37df5",
-                "sha256:de62cf699122dcef175988f0714678e59c453dc234c5b47b7136bfd7641e3c8c",
-                "sha256:de8f8999864399529e8514a2e6bfe00fd161f0a667903655552ed12e583ae3cb",
-                "sha256:f045bb5c6bfaba536089573bf97d6b8ccc7159d951fe63904c395a5e486fbe14",
-                "sha256:f103a5cdcd66cb18882ccdc18a130c31c3cfe3529732e7f10a8ab3559164819c",
-                "sha256:fe454180ad31bbbe1e5d111b44443258730467f035e26b4e354655ab59405871"
-            ],
-            "index": "pypi",
-            "version": "==1.4.0"
-        },
-        "python-dateutil": {
-            "hashes": [
-                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
-                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.8.2"
-        },
-        "pytz": {
-            "hashes": [
-                "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c",
-                "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"
-            ],
-            "version": "==2021.3"
-        },
         "requests": {
             "hashes": [
                 "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61",
@@ -117,14 +47,6 @@
             "index": "pypi",
             "version": "==2.27.1"
         },
-        "six": {
-            "hashes": [
-                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
-                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.16.0"
-        },
         "urllib3": {
             "hashes": [
                 "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
@@ -132,14 +54,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.26.8"
-        },
-        "xlrd": {
-            "hashes": [
-                "sha256:6a33ee89877bd9abc1158129f6e94be74e2679636b8a205b43b85206c3f0bbdd",
-                "sha256:f72f148f54442c6b056bf931dbc34f986fd0c3b0b6b5a58d013c9aef274d0c88"
-            ],
-            "index": "pypi",
-            "version": "==2.0.1"
         }
     },
     "develop": {

--- a/bln/client.py
+++ b/bln/client.py
@@ -7,7 +7,6 @@ import sys
 from http.client import responses
 from multiprocessing import Pool, cpu_count
 
-import pandas as pd
 import requests
 
 from . import queries as q
@@ -444,44 +443,6 @@ class Client:
                 else:
                     self.createProject(**project)
 
-    def file_to_pandas(self, projectId, fileName):
-        """Return a pandas DataFrame of `fileName` in project `projectId`.
-
-        Args:
-            projectId: the id of the project.
-            fileName: the remote file name.
-
-        Returns:
-            df: a pandas DataFrame.
-        """
-        uri = self.createFileDownloadUri(projectId, fileName)
-        if not uri:
-            return
-        return self._uri_to_pandas(uri)
-
-    def _uri_to_pands(self, uri):
-        if _is_excel(uri["name"]):
-            return pd.read_excel(uri["uri"])
-        # sep=None and engine='python' tells pandas to detect the type
-        return pd.read_table(uri["uri"], sep=None, engine="python")
-
-    def pandas_to_csv(self, df, projectId, fileName):
-        """Upload a pandas DataFrame to project `projectId` as `fileName`.
-
-        Args:
-            df: a pandas DataFrame.
-            projectId: the id of the project.
-            fileName: the remote filename.
-        """
-        if not isinstance(df, pd.DataFrame):
-            return perr("Can only upload pandas DataFrames.")
-        if os.path.splitext(fileName)[1] != ".csv":
-            return perr("Must upload to a file with a csv extension.")
-        uri = self.createFileUploadUri(projectId, fileName)
-        if not uri:
-            return
-        return _put_string(df.to_csv(index=False), uri["uri"])
-
     def search_groups(self, predicate=lambda g: re.match(".*", g["name"])):
         """Return groups where `predicate(group)` is True.
 
@@ -537,40 +498,6 @@ class Client:
                     f["projectName"] = v["project"]["name"]
                     files.append(f)
         return files
-
-    def search_to_pandas(
-        self,
-        file_predicate=lambda f: re.match(".*", f["name"]),
-        project_predicate=lambda p: re.match(".*", p["name"]),
-    ):
-        """Return matching project/file name regex to pandas DataFrame.
-
-        Args:
-            file_predicate: (optional) a function that takes a File object and
-                returns True or False.
-            project_predicate: (optional) a function that takes a project and
-                returns True or False.
-
-            The for those files that match both the `file_predicate` and
-            the `project_predicate`, the user is asked to select one to load
-            into pandas.
-
-        Returns:
-            df: a pandas DataFrame.
-        """
-        uris = []
-        for v in self.effectiveProjectRoles():
-            if project_predicate(v["project"]):
-                for f in v["project"]["files"]:
-                    if file_predicate(f):
-                        f["projectId"] = v["project"]["id"]
-                        f["projectName"] = v["project"]["name"]
-                        uris.append(f)
-        if not uris:
-            return perr("No matching files")
-        idx = _select_idx([uri["name"] for uri in uris])
-        uri = dict(enumerate(uris))[idx]
-        return self._uri_to_pands(uri)
 
 
 def _gql(
@@ -668,10 +595,6 @@ def _put_string(string, uri):
     res = requests.put(uri, data=string.encode("utf-8"), headers=headers)
     if res.status_code != requests.codes.ok:
         return responses[res.status_code]
-
-
-def _is_excel(filename):
-    return os.path.splitext(filename)[1] in [".xls", ".xlsx"]
 
 
 def _select_idx(options):

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,6 @@ setuptools.setup(
     python_requires=">=3.6",
     install_requires=[
         "requests",
-        "pandas",
-        "xlrd",
     ],
     project_urls={
         "Maintainer": "https://github.com/biglocalnews",


### PR DESCRIPTION
Fixes #30 by removing pandas features from the library. This is obviously a trade off call that is debatable. My take is that unless the pandas feature is truly essential the workflow of our users, we'd be better off slimming down this library's scope and requirements by pushing pandas work downstream. 